### PR TITLE
Fix restituteIfNeeded to allow destination changes

### DIFF
--- a/android/src/main/java/com/mfrachet/rn/views/PortalOriginGroup.java
+++ b/android/src/main/java/com/mfrachet/rn/views/PortalOriginGroup.java
@@ -16,7 +16,11 @@ public class PortalOriginGroup extends PortalViewGroup {
 
     // Buiness part
     public void restituteIfNeeded(String destinationName) {
-        if (destinationName != null || mLastDestination == null || mLastDestination.getLastOrigin() == null) {
+        if (mLastDestination == null || mLastDestination.getLastOrigin() == null) {
+            return;
+        }
+        
+        if (destinationName == mLastDestination.getName()) {
             return;
         }
 

--- a/ios/lib/ReparentableOrigin.swift
+++ b/ios/lib/ReparentableOrigin.swift
@@ -18,7 +18,7 @@ class PortalOrigin: UIView, PortalView {
   }
   
   func restituteIfNeeded(destinationName: NSString) {
-    if (destinationName == "" && lastDestination?.lastOrigin == self) {
+    if (destinationName != lastDestination?.name && lastDestination?.lastOrigin == self) {
       lastDestination?.restitute()
     }
   }


### PR DESCRIPTION
Changing a PortalOrigin's destination is not possible with out setting destination to ''.

Now it's possible to go from:

```
<PortalOrigin destination='first'></PortalOrigin>
```

to

```
<PortalOrigin destination='second'></PortalOrigin>
```

with out going to

```
<PortalOrigin destination=''></PortalOrigin>
```

in between.